### PR TITLE
Fixed issue with celery

### DIFF
--- a/temba/temba_celery.py
+++ b/temba/temba_celery.py
@@ -17,5 +17,6 @@ app.autodiscover_tasks(
         "temba.channels.types.twitter",
         "temba.channels.types.wechat",
         "temba.channels.types.whatsapp",
+        "temba.utils.management.commands.migrate_s3_buckets",
     )
 )


### PR DESCRIPTION
@teehamaral I have added a change to fix the issue with celery. However, I've found that for migrating files between different accounts, we need to configure the policy. Here is the article for reference
https://medium.com/tensult/copy-s3-bucket-objects-across-aws-accounts-e46c15c4b9e1