### PR TITLE
SonarCloud build hook.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+      - release/.*
+      - ccl-main
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
I need to setup a build-yaml that recognizes other branches so I setup
SonarCloud https://sonarcloud.io (you can access the project with your github credentials).  One main is updated to recognize the release and other long lived branches I can proceed to configure that actual sonar ci file from the targert branch and import the final product in a follow up commit one finished.